### PR TITLE
When starting foreman because the test_model included geo_coder it co…

### DIFF
--- a/app/models/paginative/test_model.rb
+++ b/app/models/paginative/test_model.rb
@@ -1,8 +1,5 @@
 module Paginative
   class TestModel < ActiveRecord::Base
-    include Paginative::ModelExtension
 
-    reverse_geocoded_by :latitude, :longitude
-    after_validation :reverse_geocode          # auto-fetch coordinates
   end
 end

--- a/spec/models/paginative/test_model_spec.rb
+++ b/spec/models/paginative/test_model_spec.rb
@@ -2,6 +2,15 @@ require_relative '../../spec_helper'
 
 describe TestModel do
 
+  before :each do
+    TestModel.class_eval do
+      include Paginative::ModelExtension
+
+      reverse_geocoded_by :latitude, :longitude
+      after_validation :reverse_geocode          # auto-fetch coordinates
+    end
+  end
+
   def create_models
     @model1 = FactoryGirl.create(:test_model, address: "Lorem", created_at: Time.now.ago(2.days))
     @model2 = FactoryGirl.create(:test_model, address: "Ipsum", created_at: Time.now.ago(1.days))


### PR DESCRIPTION
…uld potientally conflict with another gem that includes modules to ActiveRecord::Base so I moved it to a spec class_eval so the app user can include on a case by case basis.